### PR TITLE
chore(api-client): bump to 5.0.2-next.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/Innei/Innei#readme",
   "dependencies": {
-    "@mx-space/api-client": "5.0.1",
+    "@mx-space/api-client": "5.0.2-next.10",
     "@types/html-minifier": "4.0.5",
     "@types/lodash-es": "4.17.12",
     "@types/node": "24.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mx-space/api-client':
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: 5.0.2-next.10
+        version: 5.0.2-next.10
       '@types/html-minifier':
         specifier: 4.0.5
         version: 4.0.5
@@ -353,8 +353,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mx-space/api-client@5.0.1':
-    resolution: {integrity: sha512-hqldrQ/GMgiAgp3k3J8enR7/q+RyfblZSIZ2zE0u11itxpRl4xaCb7TINSuCohfAE5AkjUMVlG1TkF6Z53bQ/w==}
+  '@mx-space/api-client@5.0.2-next.10':
+    resolution: {integrity: sha512-KcOaDuwCaWBh9Qbvs/nIciMzF2TrbEW7BP+LaOiRTsLII+fWUgvmfvIZn+0mgHCiCBR4OEPOeWYDlybxIoocqw==}
     engines: {node: '>=22'}
 
   '@quansync/fs@0.1.5':
@@ -839,7 +839,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@mx-space/api-client@5.0.1':
+  '@mx-space/api-client@5.0.2-next.10':
     dependencies:
       rebuild: 0.1.2
 


### PR DESCRIPTION
## Summary

- Bump `@mx-space/api-client` from `5.0.1` to `5.0.2-next.10`
- Aligns with the V3 legacy adapter fixes (envelope shape preservation, V1→V3 `sortBy` alias)

No source changes — `mxClient.aggregate.getTimeline()` returns the unwrapped `TimelineData` under V3's default `getDataFromResponse`, which the existing `data.posts`/`data.notes` access already matches.

## Test plan
- [x] `tsc --noEmit index.ts` clean
- [ ] Daily run regenerates `readme.md` / `index.html` without errors